### PR TITLE
README.md: slightly tweak wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ go build -v .
 
 You need to run Jafar as root. You can get a complete list
 of all flags using `./jafar -help`. Jafar is composed of modules. Each
-module is controllable via flags.
+module is controllable via flags. We describe modules below.
 
 ### iptables
 


### PR DESCRIPTION
Similar rationale as ooni/netx#124: while improving wording, also make sure we don't duplicate builds by having them run on both travis-ci.com and travis-ci.org.