### PR TITLE
jafar: allow running a censored command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:edge
-RUN apk add go git musl-dev iptables tmux bind-tools curl
+RUN apk add go git musl-dev iptables tmux bind-tools curl sudo
 ENV GOPATH=/go

--- a/README.md
+++ b/README.md
@@ -39,10 +39,17 @@ module is controllable via flags. We describe modules below.
 The main module starts all the other modules. If you don't provide the
 `-main-command <command>` flag, the code will run until interrupted. If
 instead you use the `-main-command` flag, you can specify a command to
-run inside the censored environment. Use the `-main-user <username>` flag
-to select the user to use for running such command. By default, we use
-the `nobody` user for this purpose. We implement this feature using `sudo`,
-therefore you need to make sure that `sudo` is installed.
+run inside the censored environment. In such case, the main module
+will exit when the specified command terminates. Note that the main
+module will properly set the exit code if the child process fails.
+
+Note that it is not possible to pass arguments to this command. If you
+need to supply arguments to it, use a shell script.
+
+Use the `-main-user <username>` flag to select the user to use for
+running child commands. By default, we use the `nobody` user for this
+purpose. We implement this feature using `sudo`, therefore you need
+to make sure that `sudo` is installed.
 
 ### iptables
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The main module starts all the other modules. If you don't provide the
 instead you use the `-main-command` flag, you can specify a command to
 run inside the censored environment. Use the `-main-user <username>` flag
 to select the user to use for running such command. By default, we use
-the `nobody` user for this purpose.
+the `nobody` user for this purpose. We implement this feature using `sudo`,
+therefore you need to make sure that `sudo` is installed.
 
 ### iptables
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ You need to run Jafar as root. You can get a complete list
 of all flags using `./jafar -help`. Jafar is composed of modules. Each
 module is controllable via flags. We describe modules below.
 
+### main
+
+The main module starts all the other modules. If you don't provide the
+`-main-command <command>` flag, the code will run until interrupted. If
+instead you use the `-main-command` flag, you can specify a command to
+run inside the censored environment. Use the `-main-user <username>` flag
+to select the user to use for running such command. By default, we use
+the `nobody` user for this purpose.
+
 ### iptables
 
 [![GoDoc](https://godoc.org/github.com/ooni/jafar/iptables?status.svg)](
@@ -186,4 +195,10 @@ Force all traffic through the HTTP and TLS proxy and use them to censor
           -dns-proxy-hijack play.google.com      \
           -http-proxy-block play.google.com      \
           -tls-proxy-block play.google.com
+```
+
+Run `./script.sh` in a censored environment:
+
+```
+# ./jafar -iptables-drop-ip 8.8.8.8 -main-command ./script.sh
 ```

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-RUN apk add go git musl-dev iptables
+RUN apk add go git musl-dev iptables sudo
 ENV GOPATH=/go
 RUN go get github.com/mattn/goveralls
 ADD . /go/src/github.com/ooni/jafar

--- a/iptables/iptables_common.go
+++ b/iptables/iptables_common.go
@@ -3,23 +3,8 @@
 package iptables
 
 import (
-	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/apex/log"
 	"github.com/m-lab/go/rtx"
 )
-
-func runCommand(name string, arg ...string) error {
-	log.Infof("exec: %s %s", name, strings.Join(arg, " "))
-	cmd := exec.Command(name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	log.Infof("exec result: %+v", err)
-	return err
-}
 
 type shell interface {
 	dropIfDestinationEquals(ip string) error

--- a/iptables/iptables_linux.go
+++ b/iptables/iptables_linux.go
@@ -2,28 +2,30 @@
 
 package iptables
 
+import "github.com/ooni/jafar/shellx"
+
 type linuxShell struct{}
 
 func (s *linuxShell) dropIfDestinationEquals(ip string) error {
-	return runCommand("iptables", "-A", "OUTPUT", "-d", ip, "-j", "DROP")
+	return shellx.Run("iptables", "-A", "OUTPUT", "-d", ip, "-j", "DROP")
 }
 
 func (s *linuxShell) rstIfDestinationEqualsAndIsTCP(ip string) error {
-	return runCommand(
+	return shellx.Run(
 		"iptables", "-A", "OUTPUT", "--proto", "tcp", "-d", ip,
 		"-j", "REJECT", "--reject-with", "tcp-reset",
 	)
 }
 
 func (s *linuxShell) dropIfContainsKeyword(keyword string) error {
-	return runCommand(
+	return shellx.Run(
 		"iptables", "-A", "OUTPUT", "-m", "string", "--algo", "bm",
 		"--string", keyword, "-j", "DROP",
 	)
 }
 
 func (s *linuxShell) rstIfContainsKeywordAndIsTCP(keyword string) error {
-	return runCommand(
+	return shellx.Run(
 		"iptables", "-A", "OUTPUT", "-m", "string", "--proto", "tcp", "--algo",
 		"bm", "--string", keyword, "-j", "REJECT", "--reject-with", "tcp-reset",
 	)
@@ -33,15 +35,15 @@ func (s *linuxShell) hijackDNS(address string) error {
 	// Hijack any DNS query, like the Vodafone station does when using the
 	// secure network feature. Our transparent proxies will use DoT, in order
 	// to bypass this restriction and avoid routing loop.
-	return runCommand(
+	return shellx.Run(
 		"iptables", "-t", "nat", "-A", "OUTPUT", "-p", "udp",
 		"--dport", "53", "-j", "DNAT", "--to", address,
 	)
 }
 
 func (s *linuxShell) waive() error {
-	runCommand("iptables", "--flush", "--table", "nat")
-	runCommand("iptables", "--flush")
+	shellx.Run("iptables", "--flush", "--table", "nat")
+	shellx.Run("iptables", "--flush")
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,25 @@ package main
 
 import "testing"
 
-func TestLame(t *testing.T) {
+import "os"
+
+func TestIntegrationNoCommand(t *testing.T) {
 	*dnsProxyAddress = "127.0.0.1:0"
 	*httpProxyAddress = "127.0.0.1:0"
 	*tlsProxyAddress = "127.0.0.1:0"
-	close(mainCh)
+	go func() {
+		mainCh <- os.Interrupt
+	}()
+	main()
+}
+
+func TestIntegrationWithCommand(t *testing.T) {
+	*dnsProxyAddress = "127.0.0.1:0"
+	*httpProxyAddress = "127.0.0.1:0"
+	*tlsProxyAddress = "127.0.0.1:0"
+	*mainCommand = "whoami"
+	defer func() {
+		*mainCommand = ""
+	}()
 	main()
 }

--- a/shellx/shellx.go
+++ b/shellx/shellx.go
@@ -1,0 +1,21 @@
+// Package shellx allows to run commands
+package shellx
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/apex/log"
+)
+
+// Run executes the specified command with the specified args
+func Run(name string, arg ...string) error {
+	log.Infof("exec: %s %s", name, strings.Join(arg, " "))
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	log.Infof("exec result: %+v", err)
+	return err
+}

--- a/shellx/shellx_test.go
+++ b/shellx/shellx_test.go
@@ -1,0 +1,12 @@
+package shellx
+
+import "testing"
+
+func TestIntegrationRun(t *testing.T) {
+	if err := Run("whoami"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run("./nonexistent/command"); err == nil {
+		t.Fatal("expected an error here")
+	}
+}


### PR DESCRIPTION
This is part of #6. We want to run the scripts in the censored
context provided by Jafar and verify the result is okay.