### PR TITLE
iptables: implement filtering using hex strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ The iptables module is only available on Linux. It exports these flags:
 ```
   -iptables-drop-ip value
         Drop traffic to the specified IP address
+  -iptables-drop-keyword-hex value
+        Drop traffic containing the specified hex keyword
   -iptables-drop-keyword value
         Drop traffic containing the specified keyword
   -iptables-hijack-dns-to string
         Hijack all DNS UDP traffic to the specified endpoint
   -iptables-reset-ip value
         Reset TCP/IP traffic to the specified IP address
+  -iptables-reset-keyword-hex value
+        Reset TCP/IP traffic containing the specified hex keyword
   -iptables-reset-keyword value
         Reset TCP/IP traffic containing the specified keyword
 ```
@@ -89,6 +93,10 @@ operations timeout and when a connection cannot be established (with
 
 Hijacking DNS traffic is useful, for example, to redirect all DNS UDP
 traffic from the box to the `dns-proxy` module.
+
+When matching keywords, the simplest option is to use ASCII strings as
+in `-iptables-drop-keyword ooni`. However, you can also specify a sequence
+of hex bytes, as in `-iptables-drop-keyword-hex |6f 6f 6e 69|`.
 
 Note that with `-iptables-drop-keyword`, DNS queries containing such
 keyword will fail returning `EPERM`. For a more realistic approach to

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -4,5 +4,5 @@ ENV GOPATH=/go
 RUN go get github.com/mattn/goveralls
 ADD . /go/src/github.com/ooni/jafar
 WORKDIR /go/src/github.com/ooni/jafar
-CMD go test -coverprofile=jafar.cov -coverpkg=./... ./... &&                   \
+CMD go test -v -coverprofile=jafar.cov -coverpkg=./... ./... &&                \
     /go/bin/goveralls -coverprofile=jafar.cov -service=travis-ci

--- a/iptables/iptables_common.go
+++ b/iptables/iptables_common.go
@@ -10,7 +10,9 @@ type shell interface {
 	createChains() error
 	dropIfDestinationEquals(ip string) error
 	rstIfDestinationEqualsAndIsTCP(ip string) error
+	dropIfContainsKeywordHex(keyword string) error
 	dropIfContainsKeyword(keyword string) error
+	rstIfContainsKeywordHexAndIsTCP(keyword string) error
 	rstIfContainsKeywordAndIsTCP(keyword string) error
 	hijackDNS(address string) error
 	waive() error
@@ -19,9 +21,11 @@ type shell interface {
 // CensoringPolicy implements a censoring policy.
 type CensoringPolicy struct {
 	DropIPs          []string // drop IP traffic to these IPs
+	DropKeywordsHex  []string // drop IP packets with these hex keywords
 	DropKeywords     []string // drop IP packets with these keywords
 	HijackDNSAddress string   // where to hijack DNS
 	ResetIPs         []string // RST TCP/IP traffic to these IPs
+	ResetKeywordsHex []string // RST TCP/IP flows with these hex keywords
 	ResetKeywords    []string // RST TCP/IP flows with these keywords
 	sh               shell
 }
@@ -44,6 +48,10 @@ func (c *CensoringPolicy) Apply() (err error) {
 	rtx.PanicOnError(err, "c.sh.createChains failed")
 	// Implementation note: we want the RST rules to be first such
 	// that we end up enforcing them before the drop rules.
+	for _, keyword := range c.ResetKeywordsHex {
+		err = c.sh.rstIfContainsKeywordHexAndIsTCP(keyword)
+		rtx.PanicOnError(err, "c.sh.rstIfContainsKeywordHexAndIsTCP failed")
+	}
 	for _, keyword := range c.ResetKeywords {
 		err = c.sh.rstIfContainsKeywordAndIsTCP(keyword)
 		rtx.PanicOnError(err, "c.sh.rstIfContainsKeywordAndIsTCP failed")
@@ -51,6 +59,10 @@ func (c *CensoringPolicy) Apply() (err error) {
 	for _, ip := range c.ResetIPs {
 		err = c.sh.rstIfDestinationEqualsAndIsTCP(ip)
 		rtx.PanicOnError(err, "c.sh.rstIfDestinationEqualsAndIsTCP failed")
+	}
+	for _, keyword := range c.DropKeywordsHex {
+		err = c.sh.dropIfContainsKeywordHex(keyword)
+		rtx.PanicOnError(err, "c.sh.dropIfContainsKeywordHex failed")
 	}
 	for _, keyword := range c.DropKeywords {
 		err = c.sh.dropIfContainsKeyword(keyword)

--- a/iptables/iptables_linux.go
+++ b/iptables/iptables_linux.go
@@ -41,10 +41,24 @@ func (s *linuxShell) rstIfDestinationEqualsAndIsTCP(ip string) error {
 	)
 }
 
+func (s *linuxShell) dropIfContainsKeywordHex(keyword string) error {
+	return shellx.Run(
+		"iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--algo", "kmp",
+		"--hex-string", keyword, "-j", "DROP",
+	)
+}
+
 func (s *linuxShell) dropIfContainsKeyword(keyword string) error {
 	return shellx.Run(
 		"iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--algo", "kmp",
 		"--string", keyword, "-j", "DROP",
+	)
+}
+
+func (s *linuxShell) rstIfContainsKeywordHexAndIsTCP(keyword string) error {
+	return shellx.Run(
+		"iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--proto", "tcp", "--algo",
+		"kmp", "--hex-string", keyword, "-j", "REJECT", "--reject-with", "tcp-reset",
 	)
 }
 

--- a/iptables/iptables_otherwise.go
+++ b/iptables/iptables_otherwise.go
@@ -15,7 +15,13 @@ func (*otherwiseShell) dropIfDestinationEquals(ip string) error {
 func (*otherwiseShell) rstIfDestinationEqualsAndIsTCP(ip string) error {
 	return errors.New("not implemented")
 }
+func (*otherwiseShell) dropIfContainsKeywordHex(keyword string) error {
+	return errors.New("not implemented")
+}
 func (*otherwiseShell) dropIfContainsKeyword(keyword string) error {
+	return errors.New("not implemented")
+}
+func (*otherwiseShell) rstIfContainsKeywordHexAndIsTCP(keyword string) error {
 	return errors.New("not implemented")
 }
 func (*otherwiseShell) rstIfContainsKeywordAndIsTCP(keyword string) error {

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -112,7 +112,7 @@ func TestIntegrationDropKeywordHex(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if err.Error() != "Get http://www.ooni.io: context deadline exceeded" {
+	if !strings.HasSuffix(err.Error(), "operation not permitted") {
 		t.Fatal("unexpected error occurred")
 	}
 	if resp != nil {

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -92,6 +92,34 @@ func TestIntegrationDropKeyword(t *testing.T) {
 	}
 }
 
+func TestIntegrationDropKeywordHex(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("not implemented on this platform")
+	}
+	policy := NewCensoringPolicy()
+	policy.DropKeywordsHex = []string{"|6f 6f 6e 69|"}
+	if err := policy.Apply(); err != nil {
+		t.Fatal(err)
+	}
+	defer policy.Waive()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequest("GET", "http://www.ooni.io", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if err.Error() != "Get http://www.ooni.io: context deadline exceeded" {
+		t.Fatal("unexpected error occurred")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+}
+
 func TestIntegrationResetIP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
@@ -136,6 +164,27 @@ func TestIntegrationResetKeyword(t *testing.T) {
 	}
 }
 
+func TestIntegrationResetKeywordHex(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("not implemented on this platform")
+	}
+	policy := NewCensoringPolicy()
+	policy.ResetKeywordsHex = []string{"|6f 6f 6e 69|"}
+	if err := policy.Apply(); err != nil {
+		t.Fatal(err)
+	}
+	defer policy.Waive()
+	resp, err := http.Get("http://www.ooni.io")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if strings.Contains(err.Error(), "read: connection reset by peer") == false {
+		t.Fatal("unexpected error occurred")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+}
 func TestIntegrationHijackDNS(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")

--- a/main.go
+++ b/main.go
@@ -35,11 +35,13 @@ var (
 	httpProxyDNSAddress   *string
 	httpProxyDNSTransport *string
 
-	iptablesDropIP       flagx.StringArray
-	iptablesDropKeyword  flagx.StringArray
-	iptablesHijackDNSTo  *string
-	iptablesResetIP      flagx.StringArray
-	iptablesResetKeyword flagx.StringArray
+	iptablesDropIP          flagx.StringArray
+	iptablesDropKeywordHex  flagx.StringArray
+	iptablesDropKeyword     flagx.StringArray
+	iptablesHijackDNSTo     *string
+	iptablesResetIP         flagx.StringArray
+	iptablesResetKeywordHex flagx.StringArray
+	iptablesResetKeyword    flagx.StringArray
 
 	mainCh      chan os.Signal
 	mainCommand *string
@@ -102,6 +104,10 @@ func init() {
 		"Drop traffic to the specified IP address",
 	)
 	flag.Var(
+		&iptablesDropKeywordHex, "iptables-drop-keyword-hex",
+		"Drop traffic containing the specified keyword in hex",
+	)
+	flag.Var(
 		&iptablesDropKeyword, "iptables-drop-keyword",
 		"Drop traffic containing the specified keyword",
 	)
@@ -112,6 +118,10 @@ func init() {
 	flag.Var(
 		&iptablesResetIP, "iptables-reset-ip",
 		"Reset TCP/IP traffic to the specified IP address",
+	)
+	flag.Var(
+		&iptablesResetKeywordHex, "iptables-reset-keyword-hex",
+		"Reset TCP/IP traffic containing the specified keyword in hex",
 	)
 	flag.Var(
 		&iptablesResetKeyword, "iptables-reset-keyword",
@@ -169,9 +179,11 @@ func httpProxyStart() *http.Server {
 func iptablesStart() *iptables.CensoringPolicy {
 	policy := iptables.NewCensoringPolicy()
 	policy.DropIPs = iptablesDropIP
+	policy.DropKeywordsHex = iptablesDropKeywordHex
 	policy.DropKeywords = iptablesDropKeyword
 	policy.HijackDNSAddress = *iptablesHijackDNSTo
 	policy.ResetIPs = iptablesResetIP
+	policy.ResetKeywordsHex = iptablesResetKeywordHex
 	policy.ResetKeywords = iptablesResetKeyword
 	err := policy.Apply()
 	rtx.Must(err, "policy.Apply failed")


### PR DESCRIPTION
Required by #6. I have determined the most robust way to block
telegram web is to filter by the SNI bytes. This does not appear
to work using a string, so I need to introduce hex strings.