### PR TITLE
main: propagate child exit code on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The main module starts all the other modules. If you don't provide the
 instead you use the `-main-command` flag, you can specify a command to
 run inside the censored environment. In such case, the main module
 will exit when the specified command terminates. Note that the main
-module will properly set the exit code if the child process fails.
+module will propagate the child exit code, if the child fails.
 
 The command can also include arguments. Make sure you quote the arguments
 such that your shell passes the whole string to the specified option, as

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,12 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"testing"
 
-import "os"
+	"github.com/ooni/jafar/shellx"
+)
 
 func TestIntegrationNoCommand(t *testing.T) {
 	*dnsProxyAddress = "127.0.0.1:0"
@@ -23,4 +27,49 @@ func TestIntegrationWithCommand(t *testing.T) {
 		*mainCommand = ""
 	}()
 	main()
+}
+
+func TestMustx(t *testing.T) {
+	t.Run("with no error", func(t *testing.T) {
+		var called int
+		mustx(nil, "", func(int) {
+			called++
+		})
+		if called != 0 {
+			t.Fatal("should not happen")
+		}
+	})
+	t.Run("with non-exit-code error", func(t *testing.T) {
+		var (
+			called   int
+			exitcode int
+		)
+		mustx(errors.New("antani"), "", func(ec int) {
+			called++
+			exitcode = ec
+		})
+		if called != 1 {
+			t.Fatal("not called?!")
+		}
+		if exitcode != 1 {
+			t.Fatal("unexpected exitcode value")
+		}
+	})
+	t.Run("with exit-code error", func(t *testing.T) {
+		var (
+			called   int
+			exitcode int
+		)
+		err := shellx.Run("curl", "-sf", "") // cause exitcode == 3
+		mustx(err, "", func(ec int) {
+			called++
+			exitcode = ec
+		})
+		if called != 1 {
+			t.Fatal("not called?!")
+		}
+		if exitcode != 3 {
+			t.Fatal("unexpected exitcode value")
+		}
+	})
 }


### PR DESCRIPTION
This allows to write tests where the child is, e.g., curl and be
confident that the return code is the curl's return code.

This is also functional to implementing #7