### PR TITLE
Add a "bad" proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ The `-tls-proxy-block` specifies which string or strings should cause the
 proxy to return an internal-erorr alert when the incoming ClientHello's SNI
 contains one of the strings provided with this option.
 
+### bad-proxy
+
+```
+  -bad-proxy-address string
+        Address where the bad proxy should listen (default "127.0.0.1:7117")
+```
+
+The bad proxy is a proxy that reads some bytes from any incoming connection
+and then closes the connection without replying anything. This simulates a
+proxy that is not working properly, hence the name of the module.
+
 ## Examples
 
 Block `play.google.com` with RST injection, force DNS traffic to use the our

--- a/badproxy/badproxy.go
+++ b/badproxy/badproxy.go
@@ -1,0 +1,55 @@
+// Package badproxy contains a bad proxy. Specifically this proxy
+// will read some bytes from the input and then close the connection.
+package badproxy
+
+import (
+	"io"
+	"io/ioutil"
+	"net"
+	"strings"
+	"time"
+)
+
+// CensoringProxy is a bad proxy
+type CensoringProxy struct {
+	listener net.Listener
+}
+
+// NewCensoringProxy creates a new bad proxy
+func NewCensoringProxy() *CensoringProxy {
+	return new(CensoringProxy)
+}
+
+func (p *CensoringProxy) serve(conn net.Conn) {
+	deadline := time.Now().Add(250 * time.Millisecond)
+	conn.SetDeadline(deadline)
+	const maxread = 1 << 17
+	reader := io.LimitReader(conn, maxread)
+	ioutil.ReadAll(reader)
+	conn.Close()
+}
+
+func (p *CensoringProxy) run(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil && strings.Contains(
+			err.Error(), "use of closed network connection") {
+			return
+		}
+		if err == nil {
+			// It's difficult to make accept fail, so restructure
+			// the code such that we enter into the happy path
+			go p.serve(conn)
+		}
+	}
+}
+
+// Start starts the bad proxy
+func (p *CensoringProxy) Start(address string) (net.Listener, error) {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	go p.run(listener)
+	return listener, nil
+}

--- a/badproxy/badproxy_test.go
+++ b/badproxy/badproxy_test.go
@@ -1,0 +1,61 @@
+package badproxy
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIntegrationCommonCase(t *testing.T) {
+	listener := newproxy(t, "ooni.io")
+	checkdial(t, listener.Addr().String(), true)
+	killproxy(t, listener)
+}
+
+func TestIntegrationListenError(t *testing.T) {
+	proxy := NewCensoringProxy()
+	listener, err := proxy.Start("8.8.8.8:80")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if listener != nil {
+		t.Fatal("expected nil listener here")
+	}
+}
+
+func newproxy(t *testing.T, blocked string) net.Listener {
+	proxy := NewCensoringProxy()
+	listener, err := proxy.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener
+}
+
+func killproxy(t *testing.T, listener net.Listener) {
+	err := listener.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkdial(
+	t *testing.T, proxyAddr string, expectSuccess bool,
+) {
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil && expectSuccess {
+		t.Fatal(err)
+	}
+	if err == nil && !expectSuccess {
+		t.Fatal("expected failure here")
+	}
+	if conn == nil && expectSuccess {
+		t.Fatal("expected actionable conn")
+	}
+	if conn != nil && !expectSuccess {
+		t.Fatal("expected nil conn")
+	}
+	if conn != nil {
+		conn.Write([]byte("123454321"))
+		conn.Close()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -250,10 +250,14 @@ func main() {
 	flag.Parse()
 	log.SetLevel(log.DebugLevel)
 	log.SetHandler(cli.Default)
-	badProxyStart()
-	dnsProxyStart()
-	httpProxyStart()
-	tlsProxyStart()
+	badlistener := badProxyStart()
+	defer badlistener.Close()
+	dnsproxy := dnsProxyStart()
+	defer dnsproxy.Shutdown()
+	httpproxy := httpProxyStart()
+	defer httpproxy.Close()
+	tlslistener := tlsProxyStart()
+	defer tlslistener.Close()
 	policy := iptablesStart()
 	var err error
 	if *mainCommand != "" {


### PR DESCRIPTION
This proxy server will read some bytes from any connection and then just
close the connection. This triggers the "received nothing" error from cURL,
which is one of the error conditions that may happen. Personally, I have
seen this behaviour sometimes from mobile devices.

Related to #7