### PR TITLE
badproxy: handshake when using TLS

### DIFF
--- a/badproxy/badproxy_test.go
+++ b/badproxy/badproxy_test.go
@@ -29,6 +29,10 @@ func TestIntegrationTLS(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
+			if err = conn.Handshake(); err != nil {
+				conn.Close()
+				return nil, err
+			}
 			return conn, nil
 		})
 	killproxy(t, listener)


### PR DESCRIPTION
Related to #7. We want to close the connection after we are sure
that we have completed the TLS handshake.